### PR TITLE
Bump next to 15.5.9

### DIFF
--- a/modal-login/package.json
+++ b/modal-login/package.json
@@ -17,7 +17,7 @@
     "@tanstack/react-query": "^5.50.1",
     "@turnkey/api-key-stamper": "^0.4.4",
     "@turnkey/http": "^2.21.0",
-    "next": "14.2.4",
+    "next": "14.2.35",
     "react": "^18",
     "react-dom": "^18",
     "viem": "^2.25.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "blockassist"
 description = "Distributed experiments built using the MBAG multiagent environment (https://github.com/cassidylaidlaw/minecraft-building-assistance-game)."
 readme = "README.md"
 requires-python = ">=3.10,<4.0"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
   "aiofiles",
   "boto3",


### PR DESCRIPTION
## Why
After react2shell, more folks have dug into React Server Components and discovered high & medium-severity CVEs. This PR bumps us to the 15.5.9 from the [patched versions](https://vercel.com/kb/bulletin/security-bulletin-cve-2025-55184-and-cve-2025-55183#patched-versions)

## Changes proposed by this PR

- ran `npx fix-react2shell-next`

## Notes to reviewer
To test: blockassist should still run

